### PR TITLE
fix: comments being truncated in sidebar view

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Sidesy: Your Comments Sidebar For YouTube",
-  "version": "1.1.2",
+  "version": "1.2.2",
   "description": "Bring YouTube comments to the side. Dive into the comments without scrolling past the video.",
   "content_scripts": [
     {

--- a/scripts/comments.js
+++ b/scripts/comments.js
@@ -25,6 +25,44 @@ chrome.runtime.onMessage.addListener((request) => {
 });
 
 /*
+Goes through the comments, determines if the number of lines
+is more than 4, and displays the 'Read More' button
+to expand the comments.
+*/
+
+function expandComments(commentsEl) {
+  const commentTextContainer = commentsEl.querySelectorAll(
+    '#expander.style-scope.ytd-comment-renderer'
+  );
+  const lineHeight = Number.parseFloat(
+    getComputedStyle(commentTextContainer[0].querySelector('#content-text'))
+      .lineHeight
+  );
+
+  function showExpandButton(comment, shouldShow) {
+    const btnMore = comment.querySelector('#more');
+    const btnLess = comment.querySelector('#less');
+
+    if (!shouldShow) {
+      btnMore.setAttribute('hidden', '');
+      btnLess.setAttribute('hidden', '');
+      return;
+    }
+
+    btnLess.setAttribute('hidden', '');
+    btnMore.removeAttribute('hidden');
+  }
+
+  commentTextContainer.forEach((comment) => {
+    comment.querySelector('#content').offsetHeight;
+    const textContainerHeight =
+      comment.querySelector('#content-text').offsetHeight;
+    const lines = Math.ceil(textContainerHeight / lineHeight);
+    showExpandButton(comment, lines > 4);
+  });
+}
+
+/*
 Gathers info from the page, like the theme and DOM Tree.
 A button is then added to the comments section to toggle between
 default view and sidebar view, and event listeners are attached.
@@ -68,6 +106,7 @@ function activateExtension() {
     popButton.removeEventListener('click', sidebarView);
     popButton.addEventListener('click', () => {
       defaultView();
+      expandComments(commentsEl);
       commentsEl.scrollIntoView({ behavior: 'smooth' });
     });
 
@@ -79,6 +118,7 @@ function activateExtension() {
     </svg>`;
 
     sidebar.prepend(commentsEl);
+    expandComments(commentsEl);
     page.scrollIntoView({ behavior: 'smooth' });
   }
 
@@ -90,4 +130,30 @@ function activateExtension() {
   }
 
   defaultView();
+
+  // Click event listener to handle the 'Read More' and 'Show Less' button clicks.
+  function handleExpandButtonClick(e) {
+    if (
+      !e.target.classList.contains('more-button') &&
+      !e.target.classList.contains('less-button')
+    )
+      return;
+
+    const commentContainer = e.target.closest(
+      '#expander.style-scope.ytd-comment-renderer'
+    );
+    const btnMore = commentContainer.querySelector('#more');
+    const btnLess = commentContainer.querySelector('#less');
+
+    if (e.target.classList.contains('more-button')) {
+      btnMore.setAttribute('hidden', '');
+      btnLess.removeAttribute('hidden');
+      commentContainer.removeAttribute('collapsed');
+    } else {
+      btnMore.removeAttribute('hidden');
+      btnLess.setAttribute('hidden', '');
+      commentContainer.setAttribute('collapsed', '');
+    }
+  }
+  commentsEl.addEventListener('click', handleExpandButtonClick);
 }


### PR DESCRIPTION
## Problem:
YouTube uses CSS to truncate comments that are over 4 lines. When comments are loaded, YouTube checks if truncation has occurred and unhides the 'Read More' <-> 'Show Less' buttons to enable users to expand and collapse the comments.

Some comments that are loaded in the default view get truncated when switched to the sidebar view because of the shorter width. But since they loaded without truncation in default view, the 'Read More' button would not be activated for those, and there would be no way to expand them.
![image](https://user-images.githubusercontent.com/15942221/222743121-614e5edd-348e-4e5f-b2f0-4d0f7826ff02.png)



## Solution
1. Whenever the view changes, the loaded comments are parsed through and the number of lines that each comment would take is calculated.
2. If the number of lines is greater than 4, the 'Read More' button is displayed.
3. An event listener is attached to the element that holds all comments to handle the clicks. If a click occurs on a 'Read More' or 'Show Less' button, the appropriate comment is expanded/collapsed by removing/adding the `collapsed` attribute from its parent element.
![image](https://user-images.githubusercontent.com/15942221/222743359-baed7d89-6142-4b43-963c-0dd345b08dca.png)

