### PR TITLE
Add: theater mode handling

### DIFF
--- a/scripts/comments.js
+++ b/scripts/comments.js
@@ -108,7 +108,9 @@ function activateExtension() {
       videoSizeButton.click();
     }
     commentsEl.classList.add('popout', isDark ? 'dark-mode' : 'light-mode');
-    commentsEl.style.height = `${player.offsetHeight}px`;
+    setTimeout(() => {
+      commentsEl.style.height = `${player.offsetHeight}px`;
+    }, 0);
     popButton.removeEventListener('click', sidebarView);
     popButton.addEventListener('click', () => {
       defaultView();

--- a/scripts/comments.js
+++ b/scripts/comments.js
@@ -74,6 +74,9 @@ function activateExtension() {
   const player = document.querySelector('.video-stream.html5-main-video');
   const originalCommentsContainer = document.querySelector('#below');
   const sidebar = document.querySelector('#secondary-inner');
+  const videoSizeButton = document.querySelector('.ytp-size-button');
+
+  let boolTheaterMode = videoSizeButton.getAttribute('data-title-no-tooltip').includes('Default');
 
   const isDark = page.hasAttribute('dark');
   commentsEl.classList.add('extension-control');
@@ -101,6 +104,9 @@ function activateExtension() {
   }
 
   function sidebarView() {
+    if (boolTheaterMode) {
+      videoSizeButton.click();
+    }
     commentsEl.classList.add('popout', isDark ? 'dark-mode' : 'light-mode');
     commentsEl.style.height = `${player.offsetHeight}px`;
     popButton.removeEventListener('click', sidebarView);
@@ -155,5 +161,12 @@ function activateExtension() {
       commentContainer.setAttribute('collapsed', '');
     }
   }
+  videoSizeButton.addEventListener('click', () => {
+    boolTheaterMode = !boolTheaterMode;
+
+    if (boolTheaterMode) {
+      defaultView();
+    }
+  });
   commentsEl.addEventListener('click', handleExpandButtonClick);
 }


### PR DESCRIPTION
## Problems:

1. When the user is in theater mode and clicks to pin the comments to the side, the comments are stuck underneath the video. 

2. When the user has the comments pinned to the side and clicks to enter theater mode, the comments are then stuck underneath the video.

### Example: 
![example](https://github.com/abinjohn123/sidesy/assets/99842142/9b9d8df0-0d6d-48fc-a671-2d3e6155b524)

## Solution:
1. On extension start, store the video size selector button into the `videoSizeButton` variable. This element is what is used to change your video into theater or default mode.
2. After setting the `videoSizeButton` variable, check the data attribute `data-title-no-tooltip` . If the data attribute contains `Default`, set `boolTheaterMode` to `true`. If not, set it to `false`.
3. Add a click event listener to `videoSizeButton`. If a click occurs, set `boolTheaterMode` to the opposite of what it set as previously. Also, if `boolTheaterMode` is `true` after setting it, then call `defaultView()`. This fixes the second problem that I described above.
4. To fix the first problem I listed above, inside of the `sidebarView()` method check to see if `boolTheaterMode` is `true`. If it is, then fire a click onto `videoSizeButton`. This sets the video mode back to default and the comments are neatly pinned to the right. 