### PR TITLE
Save comments' position

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Sidesy: Your Comments Sidebar For YouTube",
-  "version": "1.2.3",
+  "version": "1.3.3",
   "description": "Bring YouTube comments to the side. Dive into the comments without scrolling past the video.",
   "content_scripts": [
     {

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,7 @@
   "background": {
     "service_worker": "background.js"
   },
-  "permissions": ["tabs"],
+  "permissions": ["tabs", "storage"],
   "icons": {
     "128": "images/sidesy-128.png"
   }

--- a/scripts/comments.js
+++ b/scripts/comments.js
@@ -63,6 +63,16 @@ function expandComments(commentsEl) {
 }
 
 /*
+Save current extension position locally
+*/
+
+function savePosition(position) {
+  chrome.storage.local.set({ comments_placement: position }).then(() => {
+    console.log(`${position} is set`);
+  });
+}
+
+/*
 Gathers info from the page, like the theme and DOM Tree.
 A button is then added to the comments section to toggle between
 default view and sidebar view, and event listeners are attached.
@@ -76,7 +86,9 @@ function activateExtension() {
   const sidebar = document.querySelector('#secondary-inner');
   const videoSizeButton = document.querySelector('.ytp-size-button');
 
-  let boolTheaterMode = videoSizeButton.getAttribute('data-title-no-tooltip').includes('Default');
+  let boolTheaterMode = videoSizeButton
+    .getAttribute('data-title-no-tooltip')
+    .includes('Default');
 
   const isDark = page.hasAttribute('dark');
   commentsEl.classList.add('extension-control');
@@ -101,6 +113,8 @@ function activateExtension() {
 
     originalCommentsContainer.append(commentsEl);
     commentsEl.style.display = 'block';
+
+    savePosition('default');
   }
 
   function sidebarView() {
@@ -128,6 +142,8 @@ function activateExtension() {
     sidebar.prepend(commentsEl);
     expandComments(commentsEl);
     page.scrollIntoView({ behavior: 'smooth' });
+
+    savePosition('sidebar');
   }
 
   if (!commentsEl.querySelector('header')) {
@@ -136,8 +152,6 @@ function activateExtension() {
     header.append(popButton);
     commentsEl.prepend(header);
   }
-
-  defaultView();
 
   // Click event listener to handle the 'Read More' and 'Show Less' button clicks.
   function handleExpandButtonClick(e) {
@@ -163,6 +177,7 @@ function activateExtension() {
       commentContainer.setAttribute('collapsed', '');
     }
   }
+
   videoSizeButton.addEventListener('click', () => {
     boolTheaterMode = !boolTheaterMode;
 
@@ -171,4 +186,9 @@ function activateExtension() {
     }
   });
   commentsEl.addEventListener('click', handleExpandButtonClick);
+
+  chrome.storage.local.get(['comments_placement']).then((data) => {
+    if (data.comments_placement === 'sidebar') sidebarView();
+    else defaultView();
+  });
 }

--- a/scripts/comments.js
+++ b/scripts/comments.js
@@ -34,10 +34,15 @@ function expandComments(commentsEl) {
   const commentTextContainer = commentsEl.querySelectorAll(
     '#expander.style-scope.ytd-comment-renderer'
   );
-  const lineHeight = Number.parseFloat(
-    getComputedStyle(commentTextContainer[0].querySelector('#content-text'))
-      .lineHeight
-  );
+
+  const lineHeight =
+    commentTextContainer.length > 0
+      ? Number.parseFloat(
+          getComputedStyle(
+            commentTextContainer[0].querySelector('#content-text')
+          ).lineHeight
+        )
+      : 20;
 
   function showExpandButton(comment, shouldShow) {
     const btnMore = comment.querySelector('#more');

--- a/scripts/comments.js
+++ b/scripts/comments.js
@@ -72,9 +72,7 @@ Save current extension position locally
 */
 
 function savePosition(position) {
-  chrome.storage.local.set({ comments_placement: position }).then(() => {
-    console.log(`${position} is set`);
-  });
+  chrome.storage.local.set({ comments_placement: position });
 }
 
 /*


### PR DESCRIPTION
## Issue
Comments' position was never saved earlier. Opening a new tab or window always reset them to default view.

## Feature
Use the `chrome.storage` API to save the comments' position when they're toggled. 