### PR TITLE
Scrollbar for the popout

### DIFF
--- a/scripts/styles.css
+++ b/scripts/styles.css
@@ -29,7 +29,17 @@
 }
 
 .popout::-webkit-scrollbar {
-  display: none;
+  /* display: none; */
+  width: 8px;
+}
+
+.popout::-webkit-scrollbar-track {
+  background: none;
+}
+
+::-webkit-scrollbar-thumb {
+  background: #aaa;
+  border-radius: 4px;
 }
 
 


### PR DESCRIPTION
## What's new?
Introduces a scrollbar in the popout card. Useful for non-mouse users (especially trackpad) to quickly scroll through the comments.

![image](https://github.com/abinjohn123/sidesy/assets/15942221/fb0051a0-5d3a-420e-b8f3-8126fe81129a)
![image](https://github.com/abinjohn123/sidesy/assets/15942221/65d744a9-52cc-4f90-8a45-5233e7a27e71)
