### PR TITLE
[unfixed] sidebar sometimes not loading and set comment-section in side as default and not on bottom

### DIFF
--- a/scripts/comments.js
+++ b/scripts/comments.js
@@ -12,7 +12,7 @@ chrome.runtime.onMessage.addListener((request) => {
 
     // below is an "if" statement to retry "initObserver function" if "trackedElement" is not found or loaded yet
     if (!trackedElement){
-      setTimeout(initObserver);
+      setTimeout(initObserver,0);
       return;
     }
     

--- a/scripts/comments.js
+++ b/scripts/comments.js
@@ -7,21 +7,31 @@ loaded on the page.
 chrome.runtime.onMessage.addListener((request) => {
   if (!request.activate) return;
 
-  const trackedElement = document.getElementById('content');
-  const config = {
-    childList: true,
-    subtree: true,
-  };
+  function initObserver(){ //wrap into function
+    const trackedElement = document.getElementById('content');
 
-  const callback = (mutationList, observer) => {
-    if (mutationList.some((mutation) => mutation.target.id === 'comments')) {
-      activateExtension();
-      observer.disconnect();
+    // below is an "if" statement to retry "initObserver function" if "trackedElement" is not found or loaded yet
+    if (!trackedElement){
+      setTimeout(initObserver);
+      return;
     }
-  };
-
-  const observer = new MutationObserver(callback);
-  observer.observe(trackedElement, config);
+    
+    const config = {
+      childList: true,
+      subtree: true,
+    };
+  
+    const callback = (mutationList, observer) => {
+      if (mutationList.some((mutation) => mutation.target.id === 'comments')) {
+        activateExtension();
+        observer.disconnect();
+      }
+    };
+  
+    const observer = new MutationObserver(callback);
+    observer.observe(trackedElement, config);
+  }
+  initObserver(); // start initialization
 });
 
 /*

--- a/scripts/comments.js
+++ b/scripts/comments.js
@@ -109,6 +109,8 @@ function activateExtension() {
   const popButton = document.createElement('button');
   popButton.classList.add('comments-header-btn');
 
+  sidebarView(); //calling "sidebarView" function right away so that comment-section loads as a sidebar and not a bottom comment-section from the start
+  
   function defaultView() {
     commentsEl.style.display = 'none';
     commentsEl.classList.remove('popout', 'dark-mode', 'light-mode');


### PR DESCRIPTION
I'm a noob (and my first request) so take it lightly.

There was a review from Firefox Addon Store that had the same problem as mine saying

> by Scientist07, a year ago
> It seems this add-on does not work well with tabs open in the background. I often browse youtube by opening vids in
> other tabs, then going to them when needed.
> Doing that however, I see that this add-on does not load on those inactive tabs and comments are still on the bottom. 
> The only way the addon works on those pages, is if I refresh the page


If you install the extension, open a YouTube Video in a New Tab and wait for several seconds before opening it, in my machine the extension does not work at all. 

After opening the YouTube Video in a New Tab, the extension does not work. You need to refresh the page for it to work.

My first commit 8594b1ab1ac85595f57d6bd4e3d1e6b79ac01e44 solves this. At least in my machine, personal usage and conducted basic tests. This also fixes the need for me to scroll the mouse as soon as the YouTube Video is clicked so as to make the extension load, I discussed it here #7 

My second commit 73d94e3f08ed0a192655c5c4bb9d1891c790a8cc is simple, calling the sideBar function so that the comment section is on the side from the very start.

(My third commit is technically nothing in particular)

I would be glad if this could help and improve the program. Thank you!(for creating this)



