### PR TITLE
feat: default to sidebar view on first install

### DIFF
--- a/scripts/comments.js
+++ b/scripts/comments.js
@@ -191,7 +191,7 @@ function activateExtension() {
   commentsEl.addEventListener('click', handleExpandButtonClick);
 
   chrome.storage.local.get(['comments_placement']).then((data) => {
-    if (data.comments_placement === 'sidebar') sidebarView();
-    else defaultView();
+    if (data.comments_placement === 'default') defaultView();
+    else sidebarView();
   });
 }


### PR DESCRIPTION
Previously, when a user installed Sidesy, comments stayed in their
default position until manually toggled. This caused confusion as
users thought the extension wasn't working. Now, the extension
defaults to sidebar view on first install so users immediately
see the feature in action.