### PR TITLE
Add release workflows for Chrome and Firefox

### DIFF
--- a/.github/workflows/release-chrome.yml
+++ b/.github/workflows/release-chrome.yml
@@ -61,3 +61,30 @@ jobs:
             "sidesy-chrome-v${{ inputs.version }}.zip" \
             --title "Chrome v${{ inputs.version }}" \
             --generate-notes
+
+      - name: Upload to Chrome Web Store (draft)
+        env:
+          CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+        run: |
+          ACCESS_TOKEN=$(curl -s -X POST https://oauth2.googleapis.com/token \
+            -d "refresh_token=${CHROME_REFRESH_TOKEN}" \
+            -d "client_id=${CHROME_CLIENT_ID}" \
+            -d "client_secret=${CHROME_CLIENT_SECRET}" \
+            -d "grant_type=refresh_token" | jq -r '.access_token')
+          echo "::add-mask::${ACCESS_TOKEN}"
+
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+            -H "x-goog-api-version: 2" \
+            -X PUT \
+            -T "sidesy-chrome-v${{ inputs.version }}.zip" \
+            "https://www.googleapis.com/upload/chromewebstore/v1.1/items/mlceikceecooilkgiikkopipedhjjech")
+
+          if [ "$HTTP_CODE" -ge 400 ]; then
+            echo "Upload failed with HTTP $HTTP_CODE"
+            exit 1
+          fi
+
+          echo "Draft uploaded to Chrome Web Store. Go to the developer dashboard to submit for review."

--- a/.github/workflows/release-firefox.yml
+++ b/.github/workflows/release-firefox.yml
@@ -61,3 +61,62 @@ jobs:
             "sidesy-firefox-v${{ inputs.version }}.zip" \
             --title "Firefox v${{ inputs.version }}" \
             --generate-notes
+
+      - name: Upload to Firefox Add-ons (draft)
+        env:
+          FIREFOX_JWT_ISSUER: ${{ secrets.FIREFOX_JWT_ISSUER }}
+          FIREFOX_JWT_SECRET: ${{ secrets.FIREFOX_JWT_SECRET }}
+        run: |
+          pip install PyJWT --quiet
+
+          JWT_TOKEN=$(python3 -c "
+          import jwt, time, uuid, os
+          payload = {
+              'iss': os.environ['FIREFOX_JWT_ISSUER'],
+              'iat': int(time.time()),
+              'exp': int(time.time()) + 300,
+              'jti': str(uuid.uuid4())
+          }
+          print(jwt.encode(payload, os.environ['FIREFOX_JWT_SECRET'], algorithm='HS256'))
+          ")
+          echo "::add-mask::${JWT_TOKEN}"
+
+          UPLOAD_RESPONSE=$(curl -s -X POST "https://addons.mozilla.org/api/v5/addons/upload/" \
+            -H "Authorization: JWT ${JWT_TOKEN}" \
+            -F "upload=@sidesy-firefox-v${{ inputs.version }}.zip" \
+            -F "channel=listed")
+
+          UPLOAD_UUID=$(echo "$UPLOAD_RESPONSE" | jq -r '.uuid')
+
+          if [ "$UPLOAD_UUID" = "null" ] || [ -z "$UPLOAD_UUID" ]; then
+            echo "Upload failed"
+            exit 1
+          fi
+
+          echo "Upload successful, waiting for validation..."
+          sleep 15
+
+          JWT_TOKEN=$(python3 -c "
+          import jwt, time, uuid, os
+          payload = {
+              'iss': os.environ['FIREFOX_JWT_ISSUER'],
+              'iat': int(time.time()),
+              'exp': int(time.time()) + 300,
+              'jti': str(uuid.uuid4())
+          }
+          print(jwt.encode(payload, os.environ['FIREFOX_JWT_SECRET'], algorithm='HS256'))
+          ")
+          echo "::add-mask::${JWT_TOKEN}"
+
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+            -X POST "https://addons.mozilla.org/api/v5/addons/addon/sidesy/versions/" \
+            -H "Authorization: JWT ${JWT_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{\"upload\": \"${UPLOAD_UUID}\"}")
+
+          if [ "$HTTP_CODE" -ge 400 ]; then
+            echo "Version creation failed with HTTP $HTTP_CODE"
+            exit 1
+          fi
+
+          echo "Draft uploaded to Firefox Add-ons. Go to the developer hub to submit for review."


### PR DESCRIPTION
## Summary                                                                                                                                                                    
  - Adds GitHub Actions workflows with manual triggers (`workflow_dispatch`) to automate releases for both Chrome and Firefox variants                                          
  - Each workflow bumps `manifest.json` version, commits, tags, zips extension files, creates a GitHub release, and uploads the zip to the respective store as a draft          
  - Secrets for Chrome Web Store (OAuth) and Firefox AMO (JWT) are configured in repo settings

## Test plan                                                                                                                                                                  
  - [ ] Merge to `master`                                                                                                                                                       
  - [ ] Go to Actions tab → "Release Chrome" → Run workflow with a test version                                                                                                 
  - [ ] Verify: version bump commit, tag, GitHub release with zip, draft on Chrome Web Store                                                                                    
  - [ ] Repeat for "Release Firefox" workflow                                                                                                                                   
  - [ ] Verify store uploads appear as drafts (not auto-published)