### PR TITLE
chore: harden release workflows and add OAuth token helper

### DIFF
--- a/.github/workflows/release-chrome.yml
+++ b/.github/workflows/release-chrome.yml
@@ -66,6 +66,7 @@ jobs:
             -x ".git/*" \
             -x ".github/*" \
             -x ".claude/*" \
+            -x "dev-tools/*" \
             -x "images/1.png" \
             -x "images/2.png" \
             -x "images/3.png" \

--- a/.github/workflows/release-chrome.yml
+++ b/.github/workflows/release-chrome.yml
@@ -30,15 +30,35 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add manifest.json
-          git commit -m "chore: bump version to ${{ inputs.version }}"
+          if git diff --cached --quiet; then
+            echo "No manifest changes to commit. Continuing."
+          else
+            git commit -m "chore: bump version to ${{ inputs.version }}"
+          fi
 
       - name: Create tag
-        run: git tag "chrome-v${{ inputs.version }}"
+        run: |
+          if git ls-remote --tags --exit-code origin "refs/tags/chrome-v${{ inputs.version }}" >/dev/null 2>&1; then
+            echo "Tag chrome-v${{ inputs.version }} already exists on origin. Skipping."
+            echo "TAG_EXISTS=true" >> "$GITHUB_ENV"
+          else
+            git tag "chrome-v${{ inputs.version }}"
+            echo "TAG_EXISTS=false" >> "$GITHUB_ENV"
+          fi
 
       - name: Push commit and tag
         run: |
-          git push origin master
-          git push origin "chrome-v${{ inputs.version }}"
+          if [ "$(git rev-list --count origin/master..HEAD)" -gt 0 ]; then
+            git push origin master
+          else
+            echo "No new commits to push to master."
+          fi
+
+          if [ "${TAG_EXISTS}" = "false" ]; then
+            git push origin "chrome-v${{ inputs.version }}"
+          else
+            echo "No new tag to push."
+          fi
 
       - name: Zip extension files
         run: |
@@ -57,10 +77,17 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "chrome-v${{ inputs.version }}" \
-            "sidesy-chrome-v${{ inputs.version }}.zip" \
-            --title "Chrome v${{ inputs.version }}" \
-            --generate-notes
+          if gh release view "chrome-v${{ inputs.version }}" >/dev/null 2>&1; then
+            echo "Release chrome-v${{ inputs.version }} already exists. Re-uploading asset."
+            gh release upload "chrome-v${{ inputs.version }}" \
+              "sidesy-chrome-v${{ inputs.version }}.zip" \
+              --clobber
+          else
+            gh release create "chrome-v${{ inputs.version }}" \
+              "sidesy-chrome-v${{ inputs.version }}.zip" \
+              --title "Chrome v${{ inputs.version }}" \
+              --generate-notes
+          fi
 
       - name: Upload to Chrome Web Store (draft)
         env:
@@ -68,14 +95,23 @@ jobs:
           CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
           CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
         run: |
-          ACCESS_TOKEN=$(curl -s -X POST https://oauth2.googleapis.com/token \
+          TOKEN_RESPONSE=$(curl -sS -X POST https://oauth2.googleapis.com/token \
             -d "refresh_token=${CHROME_REFRESH_TOKEN}" \
             -d "client_id=${CHROME_CLIENT_ID}" \
             -d "client_secret=${CHROME_CLIENT_SECRET}" \
-            -d "grant_type=refresh_token" | jq -r '.access_token')
+            -d "grant_type=refresh_token")
+
+          ACCESS_TOKEN=$(echo "$TOKEN_RESPONSE" | jq -r '.access_token // empty')
+          if [ -z "$ACCESS_TOKEN" ]; then
+            echo "Failed to obtain Google access token."
+            echo "$TOKEN_RESPONSE" | jq 'if type=="object" then del(.access_token, .refresh_token, .id_token) else . end'
+            exit 1
+          fi
+
           echo "::add-mask::${ACCESS_TOKEN}"
 
-          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+          RESPONSE_FILE=$(mktemp)
+          HTTP_CODE=$(curl -sS -o "$RESPONSE_FILE" -w "%{http_code}" \
             -H "Authorization: Bearer ${ACCESS_TOKEN}" \
             -H "x-goog-api-version: 2" \
             -X PUT \
@@ -84,7 +120,13 @@ jobs:
 
           if [ "$HTTP_CODE" -ge 400 ]; then
             echo "Upload failed with HTTP $HTTP_CODE"
+            if jq -e . >/dev/null 2>&1 < "$RESPONSE_FILE"; then
+              jq 'if type=="object" then del(.access_token, .refresh_token, .id_token) else . end' "$RESPONSE_FILE"
+            else
+              cat "$RESPONSE_FILE"
+            fi
             exit 1
           fi
 
+          rm -f "$RESPONSE_FILE"
           echo "Draft uploaded to Chrome Web Store. Go to the developer dashboard to submit for review."

--- a/.github/workflows/release-firefox.yml
+++ b/.github/workflows/release-firefox.yml
@@ -66,6 +66,7 @@ jobs:
             -x ".git/*" \
             -x ".github/*" \
             -x ".claude/*" \
+            -x "dev-tools/*" \
             -x "images/1.png" \
             -x "images/2.png" \
             -x "images/3.png" \

--- a/.github/workflows/release-firefox.yml
+++ b/.github/workflows/release-firefox.yml
@@ -30,15 +30,35 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add manifest.json
-          git commit -m "chore: bump version to ${{ inputs.version }}"
+          if git diff --cached --quiet; then
+            echo "No manifest changes to commit. Continuing."
+          else
+            git commit -m "chore: bump version to ${{ inputs.version }}"
+          fi
 
       - name: Create tag
-        run: git tag "firefox-v${{ inputs.version }}"
+        run: |
+          if git ls-remote --tags --exit-code origin "refs/tags/firefox-v${{ inputs.version }}" >/dev/null 2>&1; then
+            echo "Tag firefox-v${{ inputs.version }} already exists on origin. Skipping."
+            echo "TAG_EXISTS=true" >> "$GITHUB_ENV"
+          else
+            git tag "firefox-v${{ inputs.version }}"
+            echo "TAG_EXISTS=false" >> "$GITHUB_ENV"
+          fi
 
       - name: Push commit and tag
         run: |
-          git push origin firefox-support
-          git push origin "firefox-v${{ inputs.version }}"
+          if [ "$(git rev-list --count origin/firefox-support..HEAD)" -gt 0 ]; then
+            git push origin firefox-support
+          else
+            echo "No new commits to push to firefox-support."
+          fi
+
+          if [ "${TAG_EXISTS}" = "false" ]; then
+            git push origin "firefox-v${{ inputs.version }}"
+          else
+            echo "No new tag to push."
+          fi
 
       - name: Zip extension files
         run: |
@@ -57,10 +77,17 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "firefox-v${{ inputs.version }}" \
-            "sidesy-firefox-v${{ inputs.version }}.zip" \
-            --title "Firefox v${{ inputs.version }}" \
-            --generate-notes
+          if gh release view "firefox-v${{ inputs.version }}" >/dev/null 2>&1; then
+            echo "Release firefox-v${{ inputs.version }} already exists. Re-uploading asset."
+            gh release upload "firefox-v${{ inputs.version }}" \
+              "sidesy-firefox-v${{ inputs.version }}.zip" \
+              --clobber
+          else
+            gh release create "firefox-v${{ inputs.version }}" \
+              "sidesy-firefox-v${{ inputs.version }}.zip" \
+              --title "Firefox v${{ inputs.version }}" \
+              --generate-notes
+          fi
 
       - name: Upload to Firefox Add-ons (draft)
         env:

--- a/dev-tools/get-chrome-refresh-token.sh
+++ b/dev-tools/get-chrome-refresh-token.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Generate a Google OAuth refresh token for Chrome Web Store API.
+
+Usage:
+  scripts/get-chrome-refresh-token.sh --client-id <id> --client-secret <secret> [--port <port>]
+
+Options:
+  --client-id       OAuth client ID (Web application client)
+  --client-secret   OAuth client secret
+  --port            Localhost port used for redirect URI (default: 8765)
+  -h, --help        Show this help text
+
+You can also provide credentials via environment variables:
+  CHROME_CLIENT_ID
+  CHROME_CLIENT_SECRET
+EOF
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+urlencode() {
+  jq -rn --arg v "$1" '$v|@uri'
+}
+
+CLIENT_ID="${CHROME_CLIENT_ID:-}"
+CLIENT_SECRET="${CHROME_CLIENT_SECRET:-}"
+PORT="8765"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --client-id)
+      CLIENT_ID="${2:-}"
+      shift 2
+      ;;
+    --client-secret)
+      CLIENT_SECRET="${2:-}"
+      shift 2
+      ;;
+    --port)
+      PORT="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$CLIENT_ID" ] || [ -z "$CLIENT_SECRET" ]; then
+  echo "Both client ID and client secret are required." >&2
+  usage
+  exit 1
+fi
+
+require_cmd curl
+require_cmd jq
+
+REDIRECT_URI="http://localhost:${PORT}/callback"
+SCOPE="https://www.googleapis.com/auth/chromewebstore"
+AUTH_BASE="https://accounts.google.com/o/oauth2/v2/auth"
+
+AUTH_URL="${AUTH_BASE}?client_id=$(urlencode "$CLIENT_ID")&redirect_uri=$(urlencode "$REDIRECT_URI")&response_type=code&scope=$(urlencode "$SCOPE")&access_type=offline&prompt=consent"
+
+echo "Step 1: Ensure this redirect URI exists in your OAuth client:"
+echo "  ${REDIRECT_URI}"
+echo
+echo "Step 2: Open this URL in your browser and authorize:"
+echo "  ${AUTH_URL}"
+echo
+echo "Google will redirect to localhost. The page may fail to load if no local server is listening."
+echo "Copy the 'code' query parameter from the URL bar and paste it here."
+printf "Authorization code: "
+IFS= read -r AUTH_CODE
+
+if [ -z "$AUTH_CODE" ]; then
+  echo "Authorization code is required." >&2
+  exit 1
+fi
+
+TOKEN_RESPONSE="$(curl -sS -X POST "https://oauth2.googleapis.com/token" \
+  -d "code=${AUTH_CODE}" \
+  -d "client_id=${CLIENT_ID}" \
+  -d "client_secret=${CLIENT_SECRET}" \
+  -d "redirect_uri=${REDIRECT_URI}" \
+  -d "grant_type=authorization_code")"
+
+ACCESS_TOKEN="$(echo "$TOKEN_RESPONSE" | jq -r '.access_token // empty')"
+REFRESH_TOKEN="$(echo "$TOKEN_RESPONSE" | jq -r '.refresh_token // empty')"
+ERROR_CODE="$(echo "$TOKEN_RESPONSE" | jq -r '.error // empty')"
+
+if [ -n "$ERROR_CODE" ]; then
+  echo "Token exchange failed: $ERROR_CODE" >&2
+  echo "$TOKEN_RESPONSE" | jq .
+  exit 1
+fi
+
+if [ -z "$REFRESH_TOKEN" ]; then
+  echo "No refresh token returned. Full response:" >&2
+  echo "$TOKEN_RESPONSE" | jq .
+  echo
+  echo "If this is a repeat authorization, ensure 'prompt=consent' is present and approve again."
+  exit 1
+fi
+
+echo
+echo "Success. New tokens were generated."
+echo "Refresh token:"
+echo "$REFRESH_TOKEN"
+echo
+echo "Next: update GitHub secret CHROME_REFRESH_TOKEN with this value."
+echo "Optional quick check (access token presence):"
+if [ -n "$ACCESS_TOKEN" ]; then
+  echo "  Access token generated successfully."
+else
+  echo "  Access token not present in response."
+fi


### PR DESCRIPTION
## Summary
This PR improves reliability of the manual release pipelines for both Chrome and Firefox and adds a developer utility for regenerating Chrome OAuth refresh tokens.

## What changed
- Made `Release Chrome` workflow rerun-safe:
  - Skip commit when `manifest.json` version is already bumped
  - Skip tag creation/push when tag already exists
  - Skip branch push when there are no new commits
  - Reuse existing GitHub release by uploading asset with `--clobber`
- Made `Release Firefox` workflow rerun-safe with the same idempotent behavior for commit/tag/push/release steps
- Improved Chrome upload diagnostics:
  - Validate token exchange response before upload
  - Print redacted Google API error body on token/upload failures (instead of only HTTP code)
- Added `dev-tools/get-chrome-refresh-token.sh`:
  - Helper script to regenerate Chrome Web Store refresh token using OAuth consent flow
- Updated zip packaging exclusions in both release workflows to exclude `dev-tools/*`

## Why
A previous release attempt partially succeeded (commit/tag/release) and then failed at Chrome Web Store upload. Retrying the same version failed early due to non-idempotent steps (for example, "nothing to commit"). These changes make retries safe and provide better failure visibility.

## Verification
- Reviewed workflow logic paths for first-run and rerun behavior
- Verified script shell syntax with `bash -n`
- Confirmed release packaging excludes `dev-tools/*`

## Notes
- No extension runtime behavior changes
- Existing untracked local file `AGENTS.md` is not part of this PR
