### PR TITLE
Prepare v1.8.2 announcement state

### DIFF
--- a/background.js
+++ b/background.js
@@ -35,7 +35,15 @@ chrome.runtime.onInstalled.addListener((details) => {
     chrome.storage.local.set({ extension_updated_at: now });
     chrome.storage.local.get(["last_seen_announcement"]).then((data) => {
       const hasItems = CONSTANTS.ANNOUNCEMENT.items.length > 0;
-      if (hasItems && data.last_seen_announcement !== version) {
+      if (!hasItems) {
+        chrome.storage.local.set({
+          last_seen_announcement: version,
+          pending_announcement: null,
+        });
+        return;
+      }
+
+      if (data.last_seen_announcement !== version) {
         chrome.storage.local.set({ pending_announcement: version });
       }
     });

--- a/constants.js
+++ b/constants.js
@@ -39,9 +39,7 @@ const CONSTANTS = {
     },
   ],
   ANNOUNCEMENT: {
-    items: [
-      "Customise Toggle Shortcut\nThe shortcut shown in the tooltip now matches what is configured in chrome://extensions/shortcuts.",
-    ],
+    items: [],
   },
   DEVELOPER_MESSAGE: {
     enabled: true,


### PR DESCRIPTION
## Summary
- Clear the announcement list for the v1.8.2 release.
- Clear stale pending announcement state on update when there are no announcement items.

## Why
v1.8.2 is intended to release the Conduktor developer message without showing an old or false "What's New" announcement. Clearing stale pending announcement state also prevents older announcement storage from blocking the promo banner.

## Validation
- Reviewed the local diff.
- Ran `node --check background.js`.