### PR TITLE
[codex] Add expandable sidebar comments

### DIFF
--- a/scripts/comments.js
+++ b/scripts/comments.js
@@ -6,6 +6,9 @@ page navigation and then watch for comments to become ready.
 */
 
 const TOGGLE_BTN_ID = 'sidesy-toggle-btn';
+const EXPAND_COMMENTS_BTN_ID = 'sidesy-expand-comments-btn';
+const SIDEBAR_BOTTOM_PADDING = 24;
+const SIDEBAR_MIN_EXPANDED_HEIGHT = 240;
 const MAC_SHORTCUT_ICON_URLS = {
   command: chrome.runtime.getURL('images/shortcut-icons/cmd.svg'),
   control: chrome.runtime.getURL('images/shortcut-icons/control.svg'),
@@ -16,6 +19,7 @@ const MAC_SHORTCUT_ICON_URLS = {
 // State for the current navigation
 let currentObserver = null;
 let currentInterval = null;
+let activeExtensionCleanup = null;
 let activated = false;
 
 // Listen for keyboard shortcut messages from the background script
@@ -131,6 +135,10 @@ function cleanup() {
     clearInterval(currentInterval);
     currentInterval = null;
   }
+  if (activeExtensionCleanup) {
+    activeExtensionCleanup();
+    activeExtensionCleanup = null;
+  }
   activated = false;
 }
 
@@ -236,6 +244,10 @@ Save current extension position locally
 
 function savePosition(position) {
   chrome.storage.local.set({ comments_placement: position });
+}
+
+function saveSidebarExpanded(isExpanded) {
+  chrome.storage.local.set({ sidebar_comments_expanded: isExpanded });
 }
 
 /*
@@ -515,8 +527,68 @@ function activateExtension() {
   tooltip.classList.add('sidesy-tooltip');
   popButton.appendChild(tooltip);
 
+  const expandCommentsButton = document.createElement('button');
+  expandCommentsButton.id = EXPAND_COMMENTS_BTN_ID;
+  expandCommentsButton.classList.add('sidesy-expand-comments-btn');
+  expandCommentsButton.type = 'button';
+
+  const commentsShell = document.createElement('div');
+  commentsShell.classList.add('sidesy-comments-shell');
+  commentsShell.append(expandCommentsButton);
+
+  let isSidebarExpanded = false;
+
   function isSidebarMode() {
     return commentsEl.classList.contains('popout');
+  }
+
+  function getYouTubeHeaderBottom() {
+    const header = document.querySelector('#masthead-container');
+    if (!header) return 0;
+
+    return Math.max(0, header.getBoundingClientRect().bottom);
+  }
+
+  function getSidebarContentAboveHeight() {
+    const sidebarRect = sidebar.getBoundingClientRect();
+    const shellRect = commentsShell.getBoundingClientRect();
+    return Math.max(0, shellRect.top - sidebarRect.top);
+  }
+
+  function getSidebarHeight() {
+    if (!isSidebarExpanded) return player.offsetHeight;
+
+    const expandedHeight = (
+      window.innerHeight -
+      getYouTubeHeaderBottom() -
+      getSidebarContentAboveHeight() -
+      SIDEBAR_BOTTOM_PADDING
+    );
+
+    return Math.max(SIDEBAR_MIN_EXPANDED_HEIGHT, expandedHeight);
+  }
+
+  function updateExpandCommentsButton() {
+    const isVisible = isSidebarMode();
+    expandCommentsButton.hidden = !isVisible;
+    expandCommentsButton.setAttribute('aria-expanded', String(isSidebarExpanded));
+
+    if (!isVisible) return;
+
+    expandCommentsButton.textContent = isSidebarExpanded ? 'Collapse' : 'Expand';
+    expandCommentsButton.title = isSidebarExpanded ? 'Collapse comments' : 'Expand comments';
+  }
+
+  function syncSidebarHeight() {
+    if (!isSidebarMode()) return;
+
+    commentsEl.style.height = `${getSidebarHeight()}px`;
+    updateExpandCommentsButton();
+  }
+
+  function syncSidebarHeightWithNextFrame() {
+    syncSidebarHeight();
+    requestAnimationFrame(syncSidebarHeight);
   }
 
   function getActiveViewport(mode) {
@@ -637,6 +709,7 @@ function activateExtension() {
     commentsEl.style.display = 'none';
     commentsEl.classList.remove('popout', 'dark-mode', 'light-mode');
     commentsEl.style.height = 'auto';
+    updateExpandCommentsButton();
     iconContainer.innerHTML = `
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="comments-icon ${
         isDark ? 'stroke-light' : 'stroke-dark'
@@ -645,6 +718,7 @@ function activateExtension() {
       </svg>`;
 
     originalCommentsContainer.append(commentsEl);
+    commentsShell.remove();
     commentsEl.style.display = 'block';
 
     savePosition('default');
@@ -655,10 +729,6 @@ function activateExtension() {
       videoSizeButton.click();
     }
     commentsEl.classList.add('popout', isDark ? 'dark-mode' : 'light-mode');
-    commentsEl.style.height = `${player.offsetHeight}px`;
-    requestAnimationFrame(() => {
-      commentsEl.style.height = `${player.offsetHeight}px`;
-    });
     iconContainer.innerHTML = `
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="comments-icon ${
       isDark ? 'stroke-light' : 'stroke-dark'
@@ -666,7 +736,9 @@ function activateExtension() {
       <path stroke-linecap="round" stroke-linejoin="round" d="M11.25 9l-3 3m0 0l3 3m-3-3h7.5M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
     </svg>`;
 
-    sidebar.prepend(commentsEl);
+    commentsShell.prepend(commentsEl);
+    sidebar.prepend(commentsShell);
+    syncSidebarHeightWithNextFrame();
 
     savePosition('sidebar');
   }
@@ -697,6 +769,12 @@ function activateExtension() {
     switchMode(isSidebarMode() ? 'default' : 'sidebar');
   }
 
+  function handleExpandCommentsClick() {
+    isSidebarExpanded = !isSidebarExpanded;
+    syncSidebarHeight();
+    saveSidebarExpanded(isSidebarExpanded);
+  }
+
   if (!commentsEl.querySelector('header')) {
     const header = document.createElement('header');
     header.classList.add('comments-header');
@@ -713,8 +791,19 @@ function activateExtension() {
   });
   popButton.addEventListener('click', handleToggleClick);
   popButton.addEventListener('mouseenter', syncAndRenderTooltip);
+  expandCommentsButton.addEventListener('click', handleExpandCommentsClick);
+  window.addEventListener('resize', syncSidebarHeight);
+  activeExtensionCleanup = () => {
+    if (commentsShell.contains(commentsEl)) {
+      commentsShell.before(commentsEl);
+    }
+    commentsShell.remove();
+    window.removeEventListener('resize', syncSidebarHeight);
+  };
 
-  chrome.storage.local.get(['comments_placement']).then((data) => {
+  chrome.storage.local.get(['comments_placement', 'sidebar_comments_expanded']).then((data) => {
+    isSidebarExpanded = data.sidebar_comments_expanded === true;
+
     if (data.comments_placement === 'default') defaultView();
     else sidebarView();
   });

--- a/scripts/comments.js
+++ b/scripts/comments.js
@@ -131,8 +131,12 @@ function isWatchPageUrl() {
 function isEditableTarget(target) {
   if (!(target instanceof Element)) return false;
 
+  if (target.closest('input, textarea, select')) return true;
+
+  const contentEditable = target.closest('[contenteditable]');
   return Boolean(
-    target.closest('input, textarea, select, [contenteditable=""], [contenteditable="true"]')
+    contentEditable &&
+    contentEditable.getAttribute('contenteditable')?.toLowerCase() !== 'false'
   );
 }
 

--- a/scripts/comments.js
+++ b/scripts/comments.js
@@ -516,9 +516,13 @@ function activateExtension() {
   const isDark = page.hasAttribute('dark');
   commentsEl.classList.add('extension-control');
 
+  const existingHeader = commentsEl.querySelector(':scope > .comments-header');
+  if (existingHeader) existingHeader.remove();
+
   const popButton = document.createElement('button');
   popButton.id = TOGGLE_BTN_ID;
   popButton.classList.add('comments-header-btn');
+  popButton.type = 'button';
 
   const iconContainer = document.createElement('span');
   popButton.appendChild(iconContainer);
@@ -529,14 +533,22 @@ function activateExtension() {
 
   const expandCommentsButton = document.createElement('button');
   expandCommentsButton.id = EXPAND_COMMENTS_BTN_ID;
-  expandCommentsButton.classList.add('sidesy-expand-comments-btn');
+  expandCommentsButton.classList.add('comments-header-btn', 'sidesy-expand-comments-btn');
   expandCommentsButton.type = 'button';
+
+  const expandCommentsIcon = document.createElement('span');
+  expandCommentsIcon.classList.add('sidesy-expand-comments-icon');
+  expandCommentsButton.appendChild(expandCommentsIcon);
+
+  const expandCommentsTooltip = document.createElement('span');
+  expandCommentsTooltip.classList.add('sidesy-tooltip');
+  expandCommentsButton.appendChild(expandCommentsTooltip);
 
   const commentsShell = document.createElement('div');
   commentsShell.classList.add('sidesy-comments-shell');
-  commentsShell.append(expandCommentsButton);
 
   let isSidebarExpanded = false;
+  let sidebarHeightAnimationTimeout = null;
 
   function isSidebarMode() {
     return commentsEl.classList.contains('popout');
@@ -575,8 +587,28 @@ function activateExtension() {
 
     if (!isVisible) return;
 
-    expandCommentsButton.textContent = isSidebarExpanded ? 'Collapse' : 'Expand';
-    expandCommentsButton.title = isSidebarExpanded ? 'Collapse comments' : 'Expand comments';
+    const label = isSidebarExpanded ? 'Collapse comments section' : 'Expand comments section';
+    expandCommentsIcon.innerHTML = getExpandCommentsIconSvg();
+    expandCommentsTooltip.textContent = label;
+    expandCommentsButton.setAttribute('aria-label', label);
+  }
+
+  function getExpandCommentsIconSvg() {
+    if (isSidebarExpanded) {
+      return `
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="sidesy-expand-comments-svg ${
+          isDark ? 'stroke-light' : 'stroke-dark'
+        }" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M7 5l5 5 5-5M7 19l5-5 5 5" />
+        </svg>`;
+    }
+
+    return `
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="sidesy-expand-comments-svg ${
+        isDark ? 'stroke-light' : 'stroke-dark'
+      }" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M7 10l5-5 5 5M7 14l5 5 5-5" />
+      </svg>`;
   }
 
   function syncSidebarHeight() {
@@ -589,6 +621,21 @@ function activateExtension() {
   function syncSidebarHeightWithNextFrame() {
     syncSidebarHeight();
     requestAnimationFrame(syncSidebarHeight);
+  }
+
+  function setSidebarHeightAnimation(isExpanding) {
+    commentsEl.classList.remove('sidesy-height-expand', 'sidesy-height-collapse');
+    commentsEl.classList.add(isExpanding ? 'sidesy-height-expand' : 'sidesy-height-collapse');
+
+    if (sidebarHeightAnimationTimeout) {
+      clearTimeout(sidebarHeightAnimationTimeout);
+      sidebarHeightAnimationTimeout = null;
+    }
+
+    sidebarHeightAnimationTimeout = setTimeout(() => {
+      commentsEl.classList.remove('sidesy-height-expand', 'sidesy-height-collapse');
+      sidebarHeightAnimationTimeout = null;
+    }, isExpanding ? 170 : 260);
   }
 
   function getActiveViewport(mode) {
@@ -770,17 +817,17 @@ function activateExtension() {
   }
 
   function handleExpandCommentsClick() {
-    isSidebarExpanded = !isSidebarExpanded;
+    const willExpand = !isSidebarExpanded;
+    setSidebarHeightAnimation(willExpand);
+    isSidebarExpanded = willExpand;
     syncSidebarHeight();
     saveSidebarExpanded(isSidebarExpanded);
   }
 
-  if (!commentsEl.querySelector('header')) {
-    const header = document.createElement('header');
-    header.classList.add('comments-header');
-    header.append(popButton);
-    commentsEl.prepend(header);
-  }
+  const header = document.createElement('header');
+  header.classList.add('comments-header');
+  header.append(expandCommentsButton, popButton);
+  commentsEl.prepend(header);
 
   videoSizeButton.addEventListener('click', () => {
     boolTheaterMode = !boolTheaterMode;
@@ -794,6 +841,10 @@ function activateExtension() {
   expandCommentsButton.addEventListener('click', handleExpandCommentsClick);
   window.addEventListener('resize', syncSidebarHeight);
   activeExtensionCleanup = () => {
+    if (sidebarHeightAnimationTimeout) {
+      clearTimeout(sidebarHeightAnimationTimeout);
+      sidebarHeightAnimationTimeout = null;
+    }
     if (commentsShell.contains(commentsEl)) {
       commentsShell.before(commentsEl);
     }

--- a/scripts/comments.js
+++ b/scripts/comments.js
@@ -544,9 +544,6 @@ function activateExtension() {
   expandCommentsTooltip.classList.add('sidesy-tooltip');
   expandCommentsButton.appendChild(expandCommentsTooltip);
 
-  const commentsShell = document.createElement('div');
-  commentsShell.classList.add('sidesy-comments-shell');
-
   let isSidebarExpanded = false;
   let sidebarHeightAnimationTimeout = null;
 
@@ -563,8 +560,8 @@ function activateExtension() {
 
   function getSidebarContentAboveHeight() {
     const sidebarRect = sidebar.getBoundingClientRect();
-    const shellRect = commentsShell.getBoundingClientRect();
-    return Math.max(0, shellRect.top - sidebarRect.top);
+    const commentsRect = commentsEl.getBoundingClientRect();
+    return Math.max(0, commentsRect.top - sidebarRect.top);
   }
 
   function getSidebarHeight() {
@@ -765,7 +762,6 @@ function activateExtension() {
       </svg>`;
 
     originalCommentsContainer.append(commentsEl);
-    commentsShell.remove();
     commentsEl.style.display = 'block';
 
     savePosition('default');
@@ -783,8 +779,7 @@ function activateExtension() {
       <path stroke-linecap="round" stroke-linejoin="round" d="M11.25 9l-3 3m0 0l3 3m-3-3h7.5M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
     </svg>`;
 
-    commentsShell.prepend(commentsEl);
-    sidebar.prepend(commentsShell);
+    sidebar.prepend(commentsEl);
     syncSidebarHeightWithNextFrame();
 
     savePosition('sidebar');
@@ -845,10 +840,6 @@ function activateExtension() {
       clearTimeout(sidebarHeightAnimationTimeout);
       sidebarHeightAnimationTimeout = null;
     }
-    if (commentsShell.contains(commentsEl)) {
-      commentsShell.before(commentsEl);
-    }
-    commentsShell.remove();
     window.removeEventListener('resize', syncSidebarHeight);
   };
 

--- a/scripts/comments.js
+++ b/scripts/comments.js
@@ -7,6 +7,7 @@ page navigation and then watch for comments to become ready.
 
 const TOGGLE_BTN_ID = 'sidesy-toggle-btn';
 const EXPAND_COMMENTS_BTN_ID = 'sidesy-expand-comments-btn';
+const EXPAND_COMMENTS_SHORTCUT = 'Z';
 const SIDEBAR_BOTTOM_PADDING = 24;
 const SIDEBAR_MIN_EXPANDED_HEIGHT = 240;
 const MAC_SHORTCUT_ICON_URLS = {
@@ -99,6 +100,17 @@ function createMacShortcutBadge(shortcut) {
   return shortcutBadge;
 }
 
+function createShortcutBadge(shortcut) {
+  if (isMacPlatform()) {
+    return createMacShortcutBadge(shortcut);
+  }
+
+  const shortcutBadge = document.createElement('span');
+  shortcutBadge.classList.add('sidesy-tooltip-key');
+  shortcutBadge.textContent = formatShortcutText(shortcut);
+  return shortcutBadge;
+}
+
 async function getToggleShortcutInfo() {
   try {
     return await chrome.runtime.sendMessage({
@@ -114,6 +126,14 @@ async function getToggleShortcutInfo() {
 
 function isWatchPageUrl() {
   return location.href.includes(WATCH_PAGE_PATTERN);
+}
+
+function isEditableTarget(target) {
+  if (!(target instanceof Element)) return false;
+
+  return Boolean(
+    target.closest('input, textarea, select, [contenteditable=""], [contenteditable="true"]')
+  );
 }
 
 function removeAnnouncementToast() {
@@ -586,7 +606,10 @@ function activateExtension() {
 
     const label = isSidebarExpanded ? 'Collapse comments section' : 'Expand comments section';
     expandCommentsIcon.innerHTML = getExpandCommentsIconSvg();
-    expandCommentsTooltip.textContent = label;
+    expandCommentsTooltip.textContent = '';
+    const textNode = document.createElement('span');
+    textNode.textContent = label;
+    expandCommentsTooltip.append(textNode, createShortcutBadge(EXPAND_COMMENTS_SHORTCUT));
     expandCommentsButton.setAttribute('aria-label', label);
   }
 
@@ -726,16 +749,7 @@ function activateExtension() {
     tooltip.append(textNode);
 
     if (shortcutInfo?.isRegistered && shortcutInfo.shortcut) {
-      const shortcutBadge = isMacPlatform()
-        ? createMacShortcutBadge(shortcutInfo.shortcut)
-        : document.createElement('span');
-
-      if (!isMacPlatform()) {
-        shortcutBadge.classList.add('sidesy-tooltip-key');
-        shortcutBadge.textContent = formatShortcutText(shortcutInfo.shortcut);
-      }
-
-      tooltip.append(shortcutBadge);
+      tooltip.append(createShortcutBadge(shortcutInfo.shortcut));
     }
   }
 
@@ -819,6 +833,16 @@ function activateExtension() {
     saveSidebarExpanded(isSidebarExpanded);
   }
 
+  function handleExpandCommentsKeydown(event) {
+    if (event.defaultPrevented || event.repeat) return;
+    if (event.key.toLowerCase() !== 'z') return;
+    if (event.metaKey || event.ctrlKey || event.altKey) return;
+    if (!isSidebarMode() || isEditableTarget(event.target)) return;
+
+    event.preventDefault();
+    handleExpandCommentsClick();
+  }
+
   const header = document.createElement('header');
   header.classList.add('comments-header');
   header.append(expandCommentsButton, popButton);
@@ -834,12 +858,14 @@ function activateExtension() {
   popButton.addEventListener('click', handleToggleClick);
   popButton.addEventListener('mouseenter', syncAndRenderTooltip);
   expandCommentsButton.addEventListener('click', handleExpandCommentsClick);
+  document.addEventListener('keydown', handleExpandCommentsKeydown);
   window.addEventListener('resize', syncSidebarHeight);
   activeExtensionCleanup = () => {
     if (sidebarHeightAnimationTimeout) {
       clearTimeout(sidebarHeightAnimationTimeout);
       sidebarHeightAnimationTimeout = null;
     }
+    document.removeEventListener('keydown', handleExpandCommentsKeydown);
     window.removeEventListener('resize', syncSidebarHeight);
   };
 

--- a/scripts/styles.css
+++ b/scripts/styles.css
@@ -23,9 +23,14 @@
   box-sizing: border-box;
   overflow-y: scroll;
   width: 100%;
-  padding: 0 16px;
+  padding: 0 16px 24px;
   margin-bottom: 24px;
   border-radius: 12px;
+}
+
+.sidesy-comments-shell {
+  position: relative;
+  display: flow-root;
 }
 
 .popout::-webkit-scrollbar {
@@ -69,6 +74,34 @@
 
 .comments-header-btn:hover {
   opacity: 1;
+}
+
+.sidesy-expand-comments-btn {
+  position: absolute;
+  left: 50%;
+  bottom: 24px;
+  z-index: 1000;
+  transform: translate(-50%, 50%);
+  padding: 6px 14px;
+  border: none;
+  border-radius: 999px;
+  font-family: "Roboto", Arial, sans-serif;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.4;
+  cursor: pointer;
+  color: #fff;
+  background: rgba(96, 96, 96, 0.92);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.22);
+  transition: background-color 0.2s, opacity 0.2s;
+}
+
+.sidesy-expand-comments-btn:hover {
+  background: rgba(64, 64, 64, 0.95);
+}
+
+.sidesy-expand-comments-btn[hidden] {
+  display: none;
 }
 
 .comments-icon {

--- a/scripts/styles.css
+++ b/scripts/styles.css
@@ -36,11 +36,6 @@
   transition: height 210ms cubic-bezier(0.34, 1.35, 0.64, 1);
 }
 
-.sidesy-comments-shell {
-  position: relative;
-  display: flow-root;
-}
-
 .popout::-webkit-scrollbar {
   /* display: none; */
   width: 8px;

--- a/scripts/styles.css
+++ b/scripts/styles.css
@@ -28,6 +28,14 @@
   border-radius: 12px;
 }
 
+.sidesy-height-expand {
+  transition: height 130ms ease-out;
+}
+
+.sidesy-height-collapse {
+  transition: height 210ms cubic-bezier(0.34, 1.35, 0.64, 1);
+}
+
 .sidesy-comments-shell {
   position: relative;
   display: flow-root;
@@ -53,6 +61,8 @@
   top: 0;
   right: 0;
   display: flex;
+  align-items: center;
+  gap: 8px;
   justify-content: flex-end;
 }
 
@@ -64,6 +74,11 @@
 
 .comments-header-btn {
   position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
   padding: 0;
   background: none;
   border: none;
@@ -77,31 +92,33 @@
 }
 
 .sidesy-expand-comments-btn {
-  position: absolute;
-  left: 50%;
-  bottom: 24px;
-  z-index: 1000;
-  transform: translate(-50%, 50%);
-  padding: 6px 14px;
-  border: none;
-  border-radius: 999px;
-  font-family: "Roboto", Arial, sans-serif;
-  font-size: 12px;
-  font-weight: 500;
-  line-height: 1.4;
-  cursor: pointer;
-  color: #fff;
-  background: rgba(96, 96, 96, 0.92);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.22);
-  transition: background-color 0.2s, opacity 0.2s;
+  flex-shrink: 0;
 }
 
-.sidesy-expand-comments-btn:hover {
-  background: rgba(64, 64, 64, 0.95);
+.sidesy-expand-comments-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+}
+
+.sidesy-expand-comments-svg {
+  width: 22px;
+  height: 22px;
+  fill: none;
+  stroke-width: 2;
 }
 
 .sidesy-expand-comments-btn[hidden] {
   display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sidesy-height-expand,
+  .sidesy-height-collapse {
+    transition: none;
+  }
 }
 
 .comments-icon {


### PR DESCRIPTION
## Summary

- Add an expand/collapse control for sidebar comments and persist the expanded state.
- Add a `z` keyboard shortcut in sidebar mode to toggle the expanded comments section, while preserving typing in editable fields.
- Calculate expanded height from the available YouTube viewport area, accounting for the masthead and content above the comments shell.
- Move the control into the comments header with inline SVG icons and scoped height animations.

## Validation

- `node --check scripts/comments.js`
- `git diff --check`