### PR TITLE
[codex] update Conduktor promo copy

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -48,7 +48,7 @@ const CONSTANTS = {
     bodyParagraphs: [
       "I just launched a new extension called Conduktor, a Spotlight-style launcher for Chrome.",
       "Search tabs, manage tab groups, and run browser actions without leaving the keyboard. Built for keyboard-first users, productivity geeks, and tab hoarders.",
-      "Free for 30 days, no credit card needed. 🙂",
+      "Free to start. No account or credit card needed. 🙂",
     ],
     ctaLabel: "Check it out",
     remindLabel: "Remind later",


### PR DESCRIPTION
## Summary

Updates the Conduktor developer message promo copy shown in Sidesy so the final line reads: "Free to start. No account or credit card needed. 🙂"

## Impact

Users now see more accurate trial/account wording in the promo toast.

## Validation

- Verified the diff only changes the Conduktor promo copy in `constants.js`.
- Confirmed the working tree was clean after committing.
- No package manifest or test command is present in this repository.